### PR TITLE
Allow setup file to enable pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+from distutils.core import setup
+
+setup(
+    name='multiworld',
+    packages=('multiworld', ),
+)


### PR DESCRIPTION
Allows multiworld to be installed using pip (e.g. `pip install -e git+https://github.com/vitchyr/multiworld` or `pip install -e git+file://<local-base>/multiworld`)