### PR TITLE
WIP: Fix setup.py packages list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from distutils.core import setup
+from setuptools import find_packages
 
 setup(
     name='multiworld',
-    packages=('multiworld', ),
+    packages=find_packages()
 )


### PR DESCRIPTION
WIP: need to add model files to the setup.py.

The setup.py previously resulted in an empty multiworld when installing from git and only worked when installing locally.