### PR TITLE
Pick and place and image env bugfix

### DIFF
--- a/multiworld/core/image_env.py
+++ b/multiworld/core/image_env.py
@@ -78,7 +78,7 @@ class ImageEnv(ProxyEnv, MultitaskEnv):
         self._render_local = False
         img_space = Box(0, 1, (self.image_length,), dtype=np.float32)
         self._img_goal = img_space.sample() #has to be done for presampling
-        spaces = self.wrapped_env.observation_space.spaces
+        spaces = self.wrapped_env.observation_space.spaces.copy()
         spaces['observation'] = img_space
         spaces['desired_goal'] = img_space
         spaces['achieved_goal'] = img_space

--- a/multiworld/envs/mujoco/__init__.py
+++ b/multiworld/envs/mujoco/__init__.py
@@ -277,6 +277,7 @@ def register_custom_envs():
             hand_high=(0.0, 0.65, 0.2),
             action_scale=0.02,
             hide_goal_markers=True,
+            num_goals_presampled=1000,
         )
 
     )

--- a/multiworld/envs/mujoco/sawyer_xyz/sawyer_pick_and_place.py
+++ b/multiworld/envs/mujoco/sawyer_xyz/sawyer_pick_and_place.py
@@ -30,7 +30,7 @@ class SawyerPickAndPlaceEnv(MultitaskEnv, SawyerXYZEnv):
             hide_goal_markers=False,
             oracle_reset_prob=0.0,
             presampled_goals=None,
-            num_goals_presampled=10,
+            num_goals_presampled=1000,
             p_obj_in_hand=.75,
 
             **kwargs


### PR DESCRIPTION
Fix default number of pick and place presampled goals (was originally manually set on the launcher's side) and make image env observation space independent of wrapped env's.