### PR TITLE
require explicit environment registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ obs = env.reset()  # returns 'observation' concatenated to `desired_goal`
 action = policy_that_takes_in_vector(obs)
 ```
 
+## Registered environments
+This repository comes with a number of environments that are ready to be
+loaded via the `gym.make` interface. To do so, they must first be registered:
+
+```
+import multiworld
+import gym
+
+multiworld.register_all_envs()
+env = gym.make('SawyerPushNIPSEasy-v0')
+```
+
 ## Extending Obs/Goals - Debugging and Multi-Modality
 One nice thing about using Dict spaces + FlatGoalEnv is that it makes it really
 easy to extend and debug.

--- a/multiworld/__init__.py
+++ b/multiworld/__init__.py
@@ -1,0 +1,7 @@
+from multiworld.envs.mujoco import register_mujoco_envs
+from multiworld.envs.pygame import register_pygame_envs
+
+
+def register_all_envs():
+    register_mujoco_envs()
+    register_pygame_envs()

--- a/multiworld/envs/mujoco/__init__.py
+++ b/multiworld/envs/mujoco/__init__.py
@@ -4,14 +4,8 @@ import logging
 
 LOGGER = logging.getLogger(__name__)
 
-_REGISTERED = False
 
-
-def register_custom_envs():
-    global _REGISTERED
-    if _REGISTERED:
-        return
-    _REGISTERED = True
+def register_mujoco_envs():
     LOGGER.info("Registering multiworld mujoco gym environments")
     from multiworld.envs.mujoco.cameras import (
         sawyer_init_camera_zoomed_in
@@ -673,6 +667,3 @@ def create_image_48_sawyer_pickup_easy_v0():
         normalize=True,
         presampled_goals=goals,
     )
-
-
-register_custom_envs()

--- a/multiworld/envs/pygame/__init__.py
+++ b/multiworld/envs/pygame/__init__.py
@@ -1,18 +1,10 @@
-import gym
 from gym.envs.registration import register
 import logging
 
 LOGGER = logging.getLogger(__name__)
 
-_REGISTERED = False
 
-
-def register_custom_envs():
-    global _REGISTERED
-    if _REGISTERED:
-        return
-    _REGISTERED = True
-
+def register_pygame_envs():
     LOGGER.info("Registering multiworld pygame gym environments")
     register(
         id='Point2DLargeEnv-offscreen-v0',
@@ -119,6 +111,3 @@ def point2d_image_fixed_goal_v0(**kwargs):
     env = ImageEnv(env, imsize=env.render_size, transpose=True)
     env = FlatGoalEnv(env)
     return env
-
-
-register_custom_envs()


### PR DESCRIPTION
Rather than doing an implicit `import multiworld.envs.mujoco` you need to explicit register the environments.