### PR TITLE
flip the image when rednering with mujoco, so it is not upside down

### DIFF
--- a/multiworld/core/image_env.py
+++ b/multiworld/core/image_env.py
@@ -185,7 +185,7 @@ class ImageEnv(ProxyEnv, MultitaskEnv):
         if self.normalize:
             image_obs = image_obs / 255.0
         if self.transpose:
-            image_obs = image_obs.transpose()
+            image_obs = image_obs.transpose((2, 0, 1))
         assert image_obs.shape[0] == self.channels
         return image_obs.flatten()
 

--- a/multiworld/envs/mujoco/mujoco_env.py
+++ b/multiworld/envs/mujoco/mujoco_env.py
@@ -145,7 +145,7 @@ class MujocoEnv(gym.Env):
             width=width,
             height=height,
             camera_name=camera_name,
-        )
+        )[::-1,:,:]
 
     def initialize_camera(self, init_fctn):
         sim = self.sim


### PR DESCRIPTION
Mujoco rendering for some reason flips the image upside down; I propose to undo this change in `mujoco_env.py`